### PR TITLE
fix(types): correct the typings

### DIFF
--- a/createHeaderTabsComponent.tsx
+++ b/createHeaderTabsComponent.tsx
@@ -30,9 +30,10 @@ function CollapsibleHeaderTabView<T extends Route>(props: ForwardTabViewProps<T>
 
     const renderTabView = (e: { renderTabBarContainer: any }) => {
         const { Component } = props
+        const refProp = { ref: props.forwardedRef } as never
         return <Component
-            ref={props.forwardedRef}
             {...props}
+            {...refProp}
             renderTabBar={(tabbarProps) => e.renderTabBarContainer(_renderTabBar(tabbarProps))} />
     }
 

--- a/createHeaderTabsComponent.tsx
+++ b/createHeaderTabsComponent.tsx
@@ -30,7 +30,7 @@ function CollapsibleHeaderTabView<T extends Route>(props: ForwardTabViewProps<T>
 
     const renderTabView = (e: { renderTabBarContainer: any }) => {
         const { Component } = props
-        const refProp = { ref: props.forwardedRef } as never
+        const refProp = { ref: props.forwardedRef } as any
         return <Component
             {...props}
             {...refProp}

--- a/createHeaderTabsComponent.tsx
+++ b/createHeaderTabsComponent.tsx
@@ -4,9 +4,9 @@ import { GestureContainer, CollapsibleHeaderProps, GestureContainerRef } from 'r
 
 type ZTabViewProps<T extends Route> = Partial<TabViewProps<T>> &
     Pick<TabViewProps<T>, 'onIndexChange' | 'navigationState' | 'renderScene'> & CollapsibleHeaderProps
-type ForwardTabViewProps<T extends Route> = ZTabViewProps<T> & { forwardedRef: React.Ref<TabView<T>>, Component: typeof TabView }
+type ForwardTabViewProps<T extends Route> = ZTabViewProps<T> & { forwardedRef: React.Ref<typeof TabView<T>>, Component: typeof TabView }
 
-export default function createHeaderTabsComponent<T extends Route>(Component: typeof TabView, config?: {}): React.ForwardRefExoticComponent<React.PropsWithoutRef<ZTabViewProps<T>> & React.RefAttributes<TabView<T>>> {
+export default function createHeaderTabsComponent<T extends Route>(Component: typeof TabView, config?: {}): React.ForwardRefExoticComponent<React.PropsWithoutRef<ZTabViewProps<T>> & React.RefAttributes<typeof TabView<T>>> {
 
     return React.forwardRef((props: ZTabViewProps<T>, ref) => {
         return <CollapsibleHeaderTabView {...props} forwardedRef={ref} Component={Component} />


### PR DESCRIPTION
Fixes this:

```bash
    node_modules/react-native-tab-view-collapsible-header/createHeaderTabsComponent.tsx:7:90 - error TS2749: 'TabView' refers to a value, but is being used as a type here. Did you mean 'typeof TabView'?

    7 type ForwardTabViewProps<T extends Route> = ZTabViewProps<T> & { forwardedRef: React.Ref<TabView<T>>, Component: typeof TabView }
                                                                                               ~~~~~~~
    node_modules/react-native-tab-view-collapsible-header/createHeaderTabsComponent.tsx:9:203 - error TS2749: 'TabView' refers to a value, but is being used as a type here. Did you mean 'typeof TabView'?

    9 export default function createHeaderTabsComponent<T extends Route>(Component: typeof TabView, config?: {}): React.ForwardRefExoticComponent<React.PropsWithoutRef<ZTabViewProps<T>> & React.RefAttributes<TabView<T>>> {
                                                                                                                                                                                                                ~~~~~~~
```

and this

```
    node_modules/react-native-tab-view-collapsible-header/createHeaderTabsComponent.tsx:34:13 - error TS2322: Type '{ renderTabBar: (tabbarProps: SceneRendererProps & { navigationState: NavigationState<T>; }) => any; layoutDirection?: "rtl" | "ltr" | "locale" | undefined; ... 40 more ...; ref: Ref<...>; }' is not assignable to type 'IntrinsicAttributes & Omit<PagerViewProps, "initialPage" | "scrollEnabled" | "onPageScroll" | "onPageSelected" | "onPageScrollStateChanged" | "keyboardDismissMode" | "children"> & { ...; } & { ...; }'.
      Property 'ref' does not exist on type 'IntrinsicAttributes & Omit<PagerViewProps, "initialPage" | "scrollEnabled" | "onPageScroll" | "onPageSelected" | "onPageScrollStateChanged" | "keyboardDismissMode" | "children"> & { ...; } & { ...; }'.

    34             ref={props.forwardedRef}
                   ~~~
```